### PR TITLE
fix: count skip elements

### DIFF
--- a/src/ImReadyManager.ts
+++ b/src/ImReadyManager.ts
@@ -6,7 +6,7 @@ MIT license
 import Component from "@egjs/component";
 import { ElementLoader } from "./loaders/ElementLoader";
 import { ArrayFormat, ElementInfo, ImReadyEvents, ImReadyLoaderOptions, ImReadyOptions } from "./types";
-import { hasSkipAttribute, toArray, getContentElements, hasLoadingAttribute } from "./utils";
+import { toArray, getContentElements, hasLoadingAttribute } from "./utils";
 /**
  * @alias eg.ImReady
  * @extends eg.Component
@@ -61,9 +61,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
     const { prefix } = this.options;
 
     this.clear();
-    this.elementInfos = toArray(elements).filter(element => {
-      return !hasSkipAttribute(element, prefix);
-    }).map((element, index) => {
+    this.elementInfos = toArray(elements).map((element, index) => {
       const loader = this.getLoader(element, { prefix });
 
       loader.check();

--- a/src/ImReadyManager.ts
+++ b/src/ImReadyManager.ts
@@ -68,15 +68,22 @@ class ImReadyManager extends Component<ImReadyEvents> {
       loader.on("error", e => {
         this.onError(index, e.target);
       }).on("preReady", e => {
-        this.elementInfos[index].hasLoading = e.hasLoading;
+        const info = this.elementInfos[index];
+
+        info.hasLoading = e.hasLoading;
+        info.isSkip = e.isSkip;
         const isPreReady = this.checkPreReady(index);
 
         this.onPreReadyElement(index);
 
         isPreReady && this.onPreReady();
-      }).on("ready", ({ withPreReady, hasLoading }) => {
+      }).on("ready", ({ withPreReady, hasLoading, isSkip }) => {
         // Pre-ready and ready occur simultaneously
-        this.elementInfos[index].hasLoading = hasLoading;
+        const info = this.elementInfos[index];
+
+        info.hasLoading = hasLoading;
+        info.isSkip = isSkip;
+
         const isPreReady = withPreReady && this.checkPreReady(index);
         const isReady = this.checkReady(index);
 
@@ -94,6 +101,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
         hasError: false,
         isPreReady: false,
         isReady: false,
+        isSkip: false,
       };
     });
 
@@ -277,6 +285,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
      * @param {boolean} [e.isPreReady] - Whether all elements are pre-ready <ko>모든 엘리먼트가 사전 준비가 끝났는지 여부</ko>
      * @param {boolean} [e.isReady] - Whether all elements are ready <ko>모든 엘리먼트가 준비가 끝났는지 여부</ko>
      * @param {boolean} [e.hasLoading] - Whether the loading attribute has been applied <ko>loading 속성이 적용되었는지 여부</ko>
+     * @param {boolean} [e.isSkip] - Whether the check is omitted due to skip attribute <ko>skip 속성으로 인하여 체크가 생략됐는지 여부</ko>
      * @example
      * ```html
      * <div>
@@ -311,6 +320,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
       isPreReady: this.isPreReady(),
       isReady: this.isReady(),
       hasLoading: info.hasLoading,
+      isSkip: info.isSkip,
     });
   }
   private onPreReady() {
@@ -371,6 +381,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
      * @param {boolean} [e.isReady] - Whether all elements are ready <ko>모든 엘리먼트가 준비가 끝났는지 여부</ko>
      * @param {boolean} [e.hasLoading] - Whether the loading attribute has been applied <ko>loading 속성이 적용되었는지 여부</ko>
      * @param {boolean} [e.isPreReadyOver] - Whether pre-ready is over <ko>사전 준비가 끝났는지 여부</ko>
+     * @param {boolean} [e.isSkip] - Whether the check is omitted due to skip attribute <ko>skip 속성으로 인하여 체크가 생략됐는지 여부</ko>
      * @example
      * ```html
      * <div>
@@ -411,6 +422,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
 
       hasLoading: info.hasLoading,
       isPreReadyOver: this.isPreReadyOver,
+      isSkip: info.isSkip,
     });
   }
   private onReady() {

--- a/src/loaders/Loader.ts
+++ b/src/loaders/Loader.ts
@@ -18,6 +18,7 @@ export default abstract class Loader<T extends HTMLElement = any> extends Compon
   protected isPreReady = false;
   protected hasDataSize = false;
   protected hasLoading = false;
+  protected isSkip = false;
 
   constructor(element: HTMLElement, options: Partial<ImReadyLoaderOptions> = {}) {
     super();
@@ -28,9 +29,10 @@ export default abstract class Loader<T extends HTMLElement = any> extends Compon
     this.element = element as T;
     this.hasDataSize = hasSizeAttribute(element, this.options.prefix);
     this.hasLoading = hasLoadingAttribute(element);
+    this.isSkip = hasSkipAttribute(this.element);
   }
   public check() {
-    if (hasSkipAttribute(this.element) || !this.checkElement()) {
+    if (this.isSkip || hasSkipAttribute(this.element) || !this.checkElement()) {
       // I'm Ready
       this.onAlreadyReady(true);
       return false;
@@ -93,6 +95,7 @@ export default abstract class Loader<T extends HTMLElement = any> extends Compon
     this.trigger("preReady", {
       element: this.element,
       hasLoading: this.hasLoading,
+      isSkip: this.isSkip,
     });
   }
   public onReady(withPreReady: boolean) {
@@ -108,6 +111,7 @@ export default abstract class Loader<T extends HTMLElement = any> extends Compon
       element: this.element,
       withPreReady,
       hasLoading: this.hasLoading,
+      isSkip: this.isSkip,
     });
   }
   public onAlreadyError(target: HTMLElement) {

--- a/src/loaders/Loader.ts
+++ b/src/loaders/Loader.ts
@@ -6,7 +6,7 @@ MIT license
 import Component from "@egjs/component";
 import { addAutoSizer, removeAutoSizer } from "../AutoSizer";
 import { ImReadyLoaderEvents, ImReadyLoaderOptions } from "../types";
-import { removeEvent, hasSizeAttribute, hasLoadingAttribute, addEvent } from "../utils";
+import { removeEvent, hasSizeAttribute, hasLoadingAttribute, addEvent, hasSkipAttribute } from "../utils";
 
 
 export default abstract class Loader<T extends HTMLElement = any> extends Component<ImReadyLoaderEvents> {
@@ -26,11 +26,11 @@ export default abstract class Loader<T extends HTMLElement = any> extends Compon
       ...options,
     };
     this.element = element as T;
-    this.hasDataSize = hasSizeAttribute(this.element, this.options.prefix);
-    this.hasLoading = hasLoadingAttribute(this.element);
+    this.hasDataSize = hasSizeAttribute(element, this.options.prefix);
+    this.hasLoading = hasLoadingAttribute(element);
   }
   public check() {
-    if (!this.checkElement()) {
+    if (hasSkipAttribute(this.element) || !this.checkElement()) {
       // I'm Ready
       this.onAlreadyReady(true);
       return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface ElementInfo {
   isPreReady: boolean;
   hasLoading: boolean;
   isReady: boolean;
+  isSkip: boolean;
 }
 
 export interface AutoSizerElement extends HTMLElement {
@@ -79,6 +80,8 @@ export type OnPreReadyElement = {
   hasLoading: boolean;
   isPreReady: boolean;
   isReady: boolean;
+
+  isSkip: boolean;
 };
 
 /**
@@ -101,6 +104,7 @@ export type OnReadyElement = {
 
   hasError: boolean;
   isPreReadyOver: boolean;
+  isSkip: boolean;
 };
 
 /**
@@ -151,6 +155,7 @@ export type OnLoaderError = {
 export type OnLoaderPreReady = {
   element: HTMLElement;
   hasLoading: boolean;
+  isSkip: boolean;
 }
 /**
  * @memberof eg.ImReady
@@ -160,6 +165,7 @@ export type OnLoaderReady = {
   element: HTMLElement;
   withPreReady: boolean;
   hasLoading: boolean;
+  isSkip: boolean;
 }
 /**
  * @memberof eg.ImReady

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -217,7 +217,9 @@ describe("Test image", () => {
     expect(preReadyElementSpy.callCount).to.be.equals(1);
     expect(preReadySpy.args[0][0].totalCount).to.be.equals(1);
     expect(im.getTotalCount()).to.be.equals(1);
-
+    // skip
+    expect(events[0].isSkip).to.be.equals(true);
+    expect(events[1].isSkip).to.be.equals(true);
     expectOrders(events, [
       "preReadyElement", "readyElement",
       "preReady", "ready",
@@ -253,6 +255,11 @@ describe("Test image", () => {
     expect(preReadySpy.args[0][0].totalCount).to.be.equals(3);
     expect(im.getTotalCount()).to.be.equals(3);
 
+    // skip
+    expect(events[0].isSkip).to.be.equals(true);
+    expect(events[1].isSkip).to.be.equals(true);
+    // no skip
+    expect(events[2].isSkip).to.be.equals(false);
     // readyElement
     expect(events[6].isPreReadyOver).to.be.equals(true);
     expectOrders(events, [

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -187,7 +187,42 @@ describe("Test image", () => {
     expect(size1[0]).to.be.equals(size1[1]);
     expect(size2[0]).to.be.not.equals(size2[1]);
   });
+  it("should checks to ignore even if there are images in the skip element.", async () => {
+    // Given
+    el.setAttribute("data-skip", "true");
+    el.innerHTML = `
+      <img src="https://naver.github.io/egjs-infinitegrid/assets/image/19.jpg" data-width="100" data-height="100" style="width: 100%;"/>
+      <img src="https://naver.github.io/egjs-infinitegrid/assets/image/20.jpg" data-width="100" data-height="100" style="width: 100%;"/>
+      <img src="https://naver.github.io/egjs-infinitegrid/assets/image/21.jpg" data-width="100" data-height="100" style="width: 100%;"/>
+    `;
+    const readyElementSpy = spy();
+    const readySpy = spy();
+    const preReadyElementSpy = spy();
+    const preReadySpy = spy();
+    const events = checkEventOrders(im);
 
+    im.on("preReadyElement", preReadyElementSpy);
+    im.on("preReady", preReadySpy);
+    im.on("readyElement", readyElementSpy);
+    im.on("ready", readySpy);
+
+    // When
+    im.check([el]);
+
+    await waitEvent(im, "ready");
+
+    // Then
+    expect(readyElementSpy.callCount).to.be.equals(1);
+    expect(readySpy.args[0][0].totalCount).to.be.equals(1);
+    expect(preReadyElementSpy.callCount).to.be.equals(1);
+    expect(preReadySpy.args[0][0].totalCount).to.be.equals(1);
+    expect(im.getTotalCount()).to.be.equals(1);
+
+    expectOrders(events, [
+      "preReadyElement", "readyElement",
+      "preReady", "ready",
+    ]);
+  });
   it("should check that ignored when the property include a skip attribute.", async () => {
     // Given
     el.innerHTML = `
@@ -212,15 +247,16 @@ describe("Test image", () => {
     await waitEvent(im, "ready");
 
     // Then
-    expect(readyElementSpy.callCount).to.be.equals(2);
-    expect(readySpy.args[0][0].totalCount).to.be.equals(2);
-    expect(preReadyElementSpy.callCount).to.be.equals(2);
-    expect(preReadySpy.args[0][0].totalCount).to.be.equals(2);
-    expect(im.getTotalCount()).to.be.equals(2);
+    expect(readyElementSpy.callCount).to.be.equals(3);
+    expect(readySpy.args[0][0].totalCount).to.be.equals(3);
+    expect(preReadyElementSpy.callCount).to.be.equals(3);
+    expect(preReadySpy.args[0][0].totalCount).to.be.equals(3);
+    expect(im.getTotalCount()).to.be.equals(3);
 
     // readyElement
-    expect(events[4].isPreReadyOver).to.be.equals(true);
+    expect(events[6].isPreReadyOver).to.be.equals(true);
     expectOrders(events, [
+      "preReadyElement", "readyElement",
       "preReadyElement", "preReadyElement", "preReady",
       "readyElement", "readyElement", "ready",
     ]);

--- a/test/unit/video.spec.ts
+++ b/test/unit/video.spec.ts
@@ -1,4 +1,4 @@
-import { sandbox, cleanup, waitEvent, getSize } from "./utils";
+import { sandbox, cleanup, waitEvent, getSize, checkEventOrders, expectOrders } from "./utils";
 import ImReady from "../../src/index";
 import { spy } from "sinon";
 import { toArray, innerWidth, innerHeight } from "../../src/utils";
@@ -179,6 +179,8 @@ describe("Test video", () => {
     `;
     const readyElementSpy = spy();
     const readySpy = spy();
+    const events = checkEventOrders(im);
+
     im.on("readyElement", readyElementSpy);
     im.on("ready", readySpy);
 
@@ -188,9 +190,19 @@ describe("Test video", () => {
     await waitEvent(im, "ready");
 
     // Then
+    // skip
+    expect(events[0].isSkip).to.be.equals(true);
+    expect(events[1].isSkip).to.be.equals(true);
+    // no skip
+    expect(events[2].isSkip).to.be.equals(false);
     expect(readyElementSpy.callCount).to.be.equals(3);
     expect(readySpy.args[0][0].totalCount).to.be.equals(3);
     expect(im.getTotalCount()).to.be.equals(3);
+    expectOrders(events, [
+      "preReadyElement", "readyElement",
+      "preReadyElement", "preReadyElement", "preReady",
+      "readyElement", "readyElement", "ready",
+    ]);
   });
   it("should check that AutoSizer works when window resize (400 => 600)", async () => {
     // Given

--- a/test/unit/video.spec.ts
+++ b/test/unit/video.spec.ts
@@ -188,9 +188,9 @@ describe("Test video", () => {
     await waitEvent(im, "ready");
 
     // Then
-    expect(readyElementSpy.callCount).to.be.equals(2);
-    expect(readySpy.args[0][0].totalCount).to.be.equals(2);
-    expect(im.getTotalCount()).to.be.equals(2);
+    expect(readyElementSpy.callCount).to.be.equals(3);
+    expect(readySpy.args[0][0].totalCount).to.be.equals(3);
+    expect(im.getTotalCount()).to.be.equals(3);
   });
   it("should check that AutoSizer works when window resize (400 => 600)", async () => {
     // Given


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4 

* The skip element should be counted. The reason is that the index is misaligned.
* The skip element occurs preReadyElement and readyElement without any other work.

## Details
<!-- Detailed description of the change/feature -->
