### PR TITLE
Add vue2 link

### DIFF
--- a/packages/vue-imready/README.md
+++ b/packages/vue-imready/README.md
@@ -13,7 +13,9 @@
     <a href="https://naver.github.io/egjs-imready/release/latest/doc/" target="_blank"><strong>API</strong></a>
 </p>
 
-
+<p align=center>
+  ⚠️ If you're looking for ImReady for Vue 2, check out <a href="https://github.com/naver/egjs-imready/blob/master/packages/vue2-imready/README.md">@egjs/vue2-imready</a>
+</p>
 
 ## Features
 * Check that all images and videos in the container are loaded.


### PR DESCRIPTION
I accidentally committed the vue2 link in the vue3 readme to master.
https://github.com/naver/egjs-imready/commit/8b7cbec36c6b675363c1b99c9ef24100a3215f8c