### PR TITLE
fix: prevent invalid onError when destroy while check

### DIFF
--- a/src/ImReadyManager.ts
+++ b/src/ImReadyManager.ts
@@ -155,7 +155,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
     this.readyCount = 0;
     this.totalErrorCount = 0;
     this.elementInfos.forEach(info => {
-      if (!info.isReady && info.loader) {
+      if (info.loader) {
         info.loader.destroy();
       }
     });
@@ -237,10 +237,6 @@ class ImReadyManager extends Component<ImReadyEvents> {
 
   private onError(index: number, target: HTMLElement) {
     const info = this.elementInfos[index];
-
-    if (!info) {
-      return;
-    }
 
     info.hasError = true;
     /**

--- a/src/ImReadyManager.ts
+++ b/src/ImReadyManager.ts
@@ -66,7 +66,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
 
       loader.check();
       loader.on("error", e => {
-        this.elementInfos[index] && this.onError(index, e.target);
+        this.onError(index, e.target);
       }).on("preReady", e => {
         const info = this.elementInfos[index];
 
@@ -237,6 +237,10 @@ class ImReadyManager extends Component<ImReadyEvents> {
 
   private onError(index: number, target: HTMLElement) {
     const info = this.elementInfos[index];
+
+    if (!info) {
+      return;
+    }
 
     info.hasError = true;
     /**

--- a/src/ImReadyManager.ts
+++ b/src/ImReadyManager.ts
@@ -66,7 +66,7 @@ class ImReadyManager extends Component<ImReadyEvents> {
 
       loader.check();
       loader.on("error", e => {
-        this.onError(index, e.target);
+        this.elementInfos[index] && this.onError(index, e.target);
       }).on("preReady", e => {
         const info = this.elementInfos[index];
 

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -1,6 +1,6 @@
 import { sandbox, cleanup, waitEvent, getSize, checkEventOrders, expectOrders, waitFor, getImageURL } from "./utils";
 import ImReady from "../../src/index";
-import { spy, stub } from "sinon";
+import { spy } from "sinon";
 import { toArray, innerWidth, innerHeight } from "../../src/utils";
 
 describe("Test image", () => {

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -633,7 +633,7 @@ describe("Test image", () => {
     expect(readySpy.callCount).to.be.equal(0);
     expect(preReadySpy.callCount).to.be.equal(0);
   });
-  it("should check invalid error event does not occur if you destroy while check is running.", async () => {
+  it("should check that the error event does not occur twice if you destroy after ready.", async () => {
     // Given
     el.innerHTML = `
       <div>

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -640,6 +640,9 @@ describe("Test image", () => {
         <img src="https://ERR"/ loading="lazy">
       </div>
     `;
+    const errorSpy = spy();
+
+    im.on("error", errorSpy);
 
     const img = el.querySelector("img");
 
@@ -649,8 +652,6 @@ describe("Test image", () => {
       value: "lazy",
     });
 
-    const errorStub = stub(im, <any>"onError");
-
     // When
     im.check([el]);
     await waitEvent(im, "ready");
@@ -658,6 +659,6 @@ describe("Test image", () => {
     await waitFor(100);
 
     // Then
-    expect(errorStub.calledOnce).to.be.true;
+    expect(errorSpy.calledOnce).to.be.true;
   });
 });

--- a/test/unit/Image.spec.ts
+++ b/test/unit/Image.spec.ts
@@ -1,6 +1,6 @@
 import { sandbox, cleanup, waitEvent, getSize, checkEventOrders, expectOrders, waitFor, getImageURL } from "./utils";
 import ImReady from "../../src/index";
-import { spy } from "sinon";
+import { spy, stub } from "sinon";
 import { toArray, innerWidth, innerHeight } from "../../src/utils";
 
 describe("Test image", () => {
@@ -632,5 +632,32 @@ describe("Test image", () => {
     // Then
     expect(readySpy.callCount).to.be.equal(0);
     expect(preReadySpy.callCount).to.be.equal(0);
+  });
+  it("should check invalid error event does not occur if you destroy while check is running.", async () => {
+    // Given
+    el.innerHTML = `
+      <div>
+        <img src="https://ERR"/ loading="lazy">
+      </div>
+    `;
+
+    const img = el.querySelector("img");
+
+    // inject loading attribute for not supported browser
+    img.setAttribute("loading", "lazy");
+    Object.defineProperty(img, "loading", {
+      value: "lazy",
+    });
+
+    const errorStub = stub(im, <any>"onError");
+
+    // When
+    im.check([el]);
+    await waitEvent(im, "ready");
+    im.destroy();
+    await waitFor(100);
+
+    // Then
+    expect(errorStub.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
## Issue
https://github.com/naver/egjs-flicking/issues/745

## Details
If `destroy` occurs while the `check` method is running, an error may occur when entering `onError` from the `check` in progress.
This situation can occur in implementations such as:
```ts
    const contentsReadyChecker = new ImReady();
    contentsReadyChecker.on("ready", () => {
      if (this._flicking) {
        void this.render();
      }
      contentsReadyChecker.destroy();
    });
    contentsReadyChecker.check(checkingPanels.map(panel => panel.element));
```

This error can be reproduced when using `loading="lazy"` img inside a div.
[I was also able to reproduce this situation on demo as well.](https://codepen.io/malangfox/pen/JjZpbGb)

I fixed this by not running `onError` when `elementInfos` is empty due to destroy.
Can be there any way to improve this fix?